### PR TITLE
[SNOWLAKE-28] Enable CI-based static test coverage reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,16 @@ os:
 compiler:
   - clang
 
+before_install:
+  - brew update
+  - brew install pyenv
+  - eval "$(pyenv init -)"
+  - pyenv install 2.7.6
+  - pyenv global 2.7.6
+  - pyenv rehash
+  - pip install cpp-coveralls
+  - pyenv rehash
+
 script:
   - uname -a
   - cmake --version
@@ -13,5 +23,8 @@ script:
   - g++ --version
   - python --version
   - make -C libs
-  - mkdir build && cd build && cmake -DUSE_PRECOMPILED_PARSER=ON .. && make
+  - mkdir build && cd build && cmake -DUSE_PRECOMPILED_PARSER=ON -DSTATIC_COVERAGE_ENABLED=ON .. && make
   - echo "DONE"
+
+after_success:
+  - coveralls --repo-token $COVERALLS_REPO_TOKEN --include ./src/

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ compiler:
 
 before_install:
   - brew update
-  - brew install pyenv
+  - brew upgrade pyenv
   - eval "$(pyenv init -)"
   - pyenv install 2.7.6
   - pyenv global 2.7.6

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 # Snowlake
 
 [![Build Status](https://travis-ci.org/libcxx/Snowlake.svg?branch=master)](https://travis-ci.org/libcxx/Snowlake)
-[![Documentation](https://readthedocs.org/projects/snowlake/badge/?version=latest)](https://snowlake.readthedocs.io/en/latest/)
+[![Documentation Status](https://readthedocs.org/projects/snowlake/badge/?version=latest)](https://snowlake.readthedocs.io/en/latest/)
+[![Coverage Status](https://coveralls.io/repos/github/libcxx/Snowlake/badge.svg?branch=master)](https://coveralls.io/github/libcxx/Snowlake?branch=master)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 
 ## Overview

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,6 +53,12 @@ set_target_properties(snowlake
     )
 
 
+# Compiler flags for supporting debug coverage.
+if (STATIC_COVERAGE_ENABLED)
+    set_target_properties(snowlake PROPERTIES COMPILE_FLAGS "-g -O0 -fprofile-arcs -ftest-coverage")
+endif()
+
+
 # Link with dependency "Parser".
 add_dependencies(snowlake Parser)
 

--- a/src/parser/CMakeLists.txt
+++ b/src/parser/CMakeLists.txt
@@ -103,4 +103,10 @@ add_library(Parser ${parser_sources})
 set_target_properties(Parser PROPERTIES COMPILE_FLAGS "-Wno-everything")
 
 
+# Compiler flags for supporting static coverage.
+if (STATIC_COVERAGE_ENABLED)
+    set_target_properties(Parser PROPERTIES COMPILE_FLAGS "-g -O0 -fprofile-arcs -ftest-coverage")
+endif()
+
+
 ### THE END ###

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -40,6 +40,12 @@ add_executable(run_tests
 set_target_properties(run_tests PROPERTIES COMPILE_FLAGS "-Wno-everything")
 
 
+# Linker flags for supporting static coverage.
+if (STATIC_COVERAGE_ENABLED)
+    set_target_properties(run_tests PROPERTIES LINK_FLAGS "--coverage")
+endif()
+
+
 # Link against the necessary libraries.
 target_link_libraries(run_tests
     snowlake


### PR DESCRIPTION
This patch enables the build process to support CI-based static test coverage reporting.

Specifically, this patch makes CI builds on Travis-CI to be built with static coverage support turned on, and send reporting to Coveralls.io.