### PR TITLE
Create static archives for library targets and use static linking o Snowlake compiler executable

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,7 +44,7 @@ set(sources
 
 
 # Library `snowlake`.
-add_library(snowlake SHARED ${sources})
+add_library(snowlake STATIC ${sources})
 
 
 # Additional compiler flags.

--- a/src/parser/CMakeLists.txt
+++ b/src/parser/CMakeLists.txt
@@ -97,7 +97,7 @@ else()
 endif()
 
 
-add_library(Parser SHARED ${parser_sources})
+add_library(Parser STATIC ${parser_sources})
 
 
 # Auto-generated code from Flex and Bison have a lot of warnings.


### PR DESCRIPTION
This patch makes it such that the two library build targets output static archives, namely `libParser.a` and `libsnowlake.a`, and that they are statically linked to the Snowlake compiler `snowlake`.