### PR TITLE
Assert Snowlake compiler warning and error messages in integration tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,8 @@ jobs:
       run: gcc --version
     - name: identify-clang
       run: clang --version
+    - name: identify-python
+      run: python3 --version
     - name: prebuild
       run: make -C libs
     - name: build

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -220,11 +220,15 @@ class TestRunner(object):
             self.__log_error('Test case \"{}\" does not have valid input'.format(testcase_name))
             return self.StatusCode.ERROR
 
-        cmd = '{executable} --silent --output ./ {input_path}'.format(
+        cmd = '{executable} --errors --output ./ {input_path}'.format(
             executable=self.executable_invoke_name,
             input_path=testcase_inputpath)
 
-        return_code = subprocess.call(cmd, shell=True)
+        completed_process = subprocess.run(cmd, shell=True, capture_output=True)
+
+        return_code = completed_process.returncode
+
+        print(f'stderr={completed_process.stdout}')
 
         err = self.StatusCode.SUCCESS if return_code == testcase_expected_exit else self.StatusCode.FAILURE
 

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -237,6 +237,7 @@ class TestRunner(object):
 
         if formatted_stderr != stderr_str:
             self.console_logger.error(f'Expected errors: {formatted_stderr}, but got {stderr_str}')
+            err = self.StatusCode.ERROR
 
         if err == self.StatusCode.SUCCESS:
             self.__log_success('[{}] - {}'.format(testcase_name, self.StatusCode.tostring(err)))

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -225,7 +225,7 @@ class TestRunner(object):
             executable=self.executable_invoke_name,
             input_path=testcase_inputpath)
 
-        completed_process = subprocess.run(cmd, shell=True, capture_output=True)
+        completed_process = subprocess.run(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
         return_code = completed_process.returncode
 

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -256,10 +256,12 @@ class TestRunner(object):
         if not expected_errors:
             return ''
 
+        pedantic = 'error' if len(expected_errors) == 1 else 'errors'
+
         return '\n'.join([
             f'{input_path}: error: {error_msg}'
             for error_msg in expected_errors
-        ]) + '\n\n' + f'{len(expected_errors)} errors generated.\n'
+        ]) + '\n\n' + f'{len(expected_errors)} {pedantic} generated.\n'
 
     def __log_msg(self, msg, color=None):
         if color:

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -236,7 +236,10 @@ class TestRunner(object):
         formatted_stderr = self.__formatted_errors(testcase_inputpath, testcase_expected_errors)
 
         if formatted_stderr != stderr_str:
-            self.console_logger.error(f'Expected errors: {formatted_stderr}, but got {stderr_str}')
+            self.console_logger.error('Expected errors: {formatted_stderr}, but got {stderr_str}'.format(
+                formatted_str=formatted_str,
+                stderr_str=stderr_str
+            ))
             err = self.StatusCode.ERROR
 
         if err == self.StatusCode.SUCCESS:
@@ -259,10 +262,14 @@ class TestRunner(object):
 
         pedantic = 'error' if len(expected_errors) == 1 else 'errors'
 
+        tail = '{num_expected_errors} {pedantic} generated.\n'.format(
+            num_expected_errors=len(expected_errors),
+            pedantic=pedantic)
+
         return '\n'.join([
-            f'{input_path}: error: {error_msg}'
+            '{input_path}: error: {error_msg}'.format(input_path=input_path, error_msg=error_msg)
             for error_msg in expected_errors
-        ]) + '\n\n' + f'{len(expected_errors)} {pedantic} generated.\n'
+        ]) + '\n\n' + tail
 
     def __log_msg(self, msg, color=None):
         if color:

--- a/tests/test_duplicate_groups.json
+++ b/tests/test_duplicate_groups.json
@@ -1,5 +1,8 @@
 {
   "name": "Test duplicate groups",
   "input_path": "./fixtures/duplicate_groups.sl",
-  "expected_exit": 1
+  "expected_exit": 1,
+  "expected_errors": [
+    "Found multiple inference group with name \"MyGroup\"."
+  ]
 }

--- a/tests/test_incompatible_array_type_target.json
+++ b/tests/test_incompatible_array_type_target.json
@@ -3,6 +3,6 @@
   "input_path": "./fixtures/incompatible_array_type_target.sl",
   "expected_exit": 1,
   "expected_errors": [
-    "Found duplicate and incompatible target in inference \"MethodStaticDispatch\""
+    "Found duplicate and incompatible target in inference \"MethodStaticDispatch\"."
   ]
 }

--- a/tests/test_incompatible_array_type_target.json
+++ b/tests/test_incompatible_array_type_target.json
@@ -1,5 +1,8 @@
 {
   "name": "Test repeated incompatible array type target in premise definition",
   "input_path": "./fixtures/incompatible_array_type_target.sl",
-  "expected_exit": 1
+  "expected_exit": 1,
+  "expected_errors": [
+    "Found duplicate and incompatible target in inference \"MethodStaticDispatch\""
+  ]
 }

--- a/tests/test_incompatible_targets_in_range_clause.json
+++ b/tests/test_incompatible_targets_in_range_clause.json
@@ -3,7 +3,7 @@
   "input_path": "./fixtures/incompatible_targets_in_range_clause.sl",
   "expected_exit": 1,
   "expected_errors": [
-    "Incompatible targets in expression in inference \"MethodStaticDispatch\"",
-    "Invalid target in range clause in inference \"MethodStaticDispatch\""
+    "Incompatible targets in expression in inference \"MethodStaticDispatch\".",
+    "Invalid target in range clause in inference \"MethodStaticDispatch\"."
   ]
 }

--- a/tests/test_incompatible_targets_in_range_clause.json
+++ b/tests/test_incompatible_targets_in_range_clause.json
@@ -1,5 +1,9 @@
 {
   "name": "Test incompatible targets in range clause",
   "input_path": "./fixtures/incompatible_targets_in_range_clause.sl",
-  "expected_exit": 1
+  "expected_exit": 1,
+  "expected_errors": [
+    "Incompatible targets in expression in inference \"MethodStaticDispatch\"",
+    "Invalid target in range clause in inference \"MethodStaticDispatch\""
+  ]
 }

--- a/tests/test_invalid_keyword.json
+++ b/tests/test_invalid_keyword.json
@@ -1,5 +1,6 @@
 {
   "name": "Test invalid keyword",
   "input_path": "./fixtures/invalid_keyword.sl",
-  "expected_exit": 1
+  "expected_exit": 1,
+  "expected_errors": []
 }

--- a/tests/test_invalid_nested_premise.json
+++ b/tests/test_invalid_nested_premise.json
@@ -4,6 +4,6 @@
   "expected_exit": 1,
   "expected_errors": [
     "Incompatible targets in expression in inference \"MethodStaticDispatch\".",
-    "Invalid target in range clause in inference \"MethodStaticDispatch\""
+    "Invalid target in range clause in inference \"MethodStaticDispatch\"."
   ]
 }

--- a/tests/test_invalid_nested_premise.json
+++ b/tests/test_invalid_nested_premise.json
@@ -1,5 +1,9 @@
 {
   "name": "Test invalid premise nested in while clause",
   "input_path": "./fixtures/invalid_nested_premise.sl",
-  "expected_exit": 1
+  "expected_exit": 1,
+  "expected_errors": [
+    "Incompatible targets in expression in inference \"MethodStaticDispatch\".",
+    "Invalid target in range clause in inference \"MethodStaticDispatch\""
+  ]
 }

--- a/tests/test_invalid_proposition.json
+++ b/tests/test_invalid_proposition.json
@@ -1,5 +1,8 @@
 {
   "name": "Test invalid proposition",
   "input_path": "./fixtures/invalid_proposition.sl",
-  "expected_exit": 1
+  "expected_exit": 1,
+  "expected_errors": [
+    "Invalid proposition target type in inference \"MethodStaticDispatch\"."
+  ]
 }

--- a/tests/test_invalid_range_clause.json
+++ b/tests/test_invalid_range_clause.json
@@ -1,5 +1,8 @@
 {
   "name": "Test invalid range clause",
   "input_path": "./fixtures/invalid_range_clause.sl",
-  "expected_exit": 1
+  "expected_exit": 1,
+  "expected_errors": [
+    "Invalid target in range clause in inference \"MethodStaticDispatch\"."
+  ]
 }

--- a/tests/test_repeated_target_in_premise.json
+++ b/tests/test_repeated_target_in_premise.json
@@ -1,5 +1,8 @@
 {
   "name": "Test repeated incompatible target in premise definition",
   "input_path": "./fixtures/repeated_target_in_premise.sl",
-  "expected_exit": 1
+  "expected_exit": 1,
+  "expected_errors": [
+    "Found duplicate and incompatible target in inference \"MethodStaticDispatch\"."
+  ]
 }

--- a/tests/test_repeating_symbol.json
+++ b/tests/test_repeating_symbol.json
@@ -1,5 +1,9 @@
 {
   "name": "Test repeating symbol",
   "input_path": "./fixtures/repeating_symbol.sl",
-  "expected_exit": 1
+  "expected_exit": 1,
+  "expected_errors": [
+    "Found duplicate symbol (argument) with name \"Arg1\".",
+    "Invalid proposition target type in inference \"MyInference\"."
+  ]
 }


### PR DESCRIPTION
This patch incorporates assertions on compiler warning and error messages in integration tests. Doing this will provide higher confidence in running the integration tests, as well as forcing to be proactive on updating the tests upon relevant changes in the source code.