### PR TITLE
Fix for Issue #55

### DIFF
--- a/src/ProgramDriver.cpp
+++ b/src/ProgramDriver.cpp
@@ -79,11 +79,9 @@ ProgramDriver::run(int argc, char** argv)
   }
 
   // Parsing.
-  ParserDriver::Options parserOpts{
-      .traceLexer = cmdlOpts.debugMode,
-      .traceParser = cmdlOpts.debugMode,
-      .suppressErrorMessages = !(cmdlOpts.debugMode),
-  };
+  ParserDriver::Options parserOpts{.traceLexer = cmdlOpts.debugMode,
+                                   .traceParser = cmdlOpts.debugMode,
+                                   .suppressErrorMessages = false};
 
   ParserDriver parser(parserOpts);
   res = parser.parseFromFile(cmdlOpts.inputPath);

--- a/src/parser/ParserDriver.cpp
+++ b/src/parser/ParserDriver.cpp
@@ -25,9 +25,10 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "lex.yy.hh"
 #include "parser.tab.hh"
 
+#include <cstdio>
 #include <fstream>
-#include <iostream>
 #include <iterator>
+#include <sstream>
 
 // -----------------------------------------------------------------------------
 
@@ -113,10 +114,10 @@ ParserDriver::parseFromFile(const std::string& filepath)
   if (!infile.good()) {
     return -1;
   }
-  std::string file_contents((std::istreambuf_iterator<char>(infile)),
-                            std::istreambuf_iterator<char>());
+  std::string fileContent((std::istreambuf_iterator<char>(infile)),
+                          std::istreambuf_iterator<char>());
   infile.close();
-  return parseFromString(file_contents.c_str());
+  return parseFromString(fileContent.c_str());
 }
 
 // -----------------------------------------------------------------------------
@@ -184,7 +185,9 @@ void
 ParserDriver::error(const yy::location& l, const std::string& m)
 {
   if (!suppressErrorMessages()) {
-    std::cerr << "Parser error [" << l << "] : " << m << std::endl;
+    std::stringstream ss;
+    ss << l;
+    fprintf(stderr, "Parser error: %s [%s]\n", m.c_str(), ss.str().c_str());
   }
 }
 
@@ -194,7 +197,7 @@ void
 ParserDriver::error(const std::string& m)
 {
   if (!suppressErrorMessages()) {
-    std::cerr << "Parser error: " << m << std::endl;
+    fprintf(stderr, "Parser error: %s\n", m.c_str());
   }
 }
 

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -237,7 +237,7 @@ class TestRunner(object):
 
         if formatted_stderr != stderr_str:
             self.console_logger.error('Expected errors: {formatted_stderr}, but got {stderr_str}'.format(
-                formatted_str=formatted_str,
+                formatted_stderr=formatted_stderr,
                 stderr_str=stderr_str
             ))
             err = self.StatusCode.ERROR


### PR DESCRIPTION
# Fix for Issue #55

This patch fixes Issue #55 where the snowlake compiler does not emit error messages on syntax errors in the input.

With the fix:

```
› ./build/src/snowlake --errors -o . tests/fixtures/invalid_keyword.sl 
Parser error: syntax error, unexpected IDENTIFIER, expecting KEYWORD_WHILE or SEMICOLON [12.67-68]
```