### PR TITLE
Minor refinement on interfaces

### DIFF
--- a/src/ASTUtils.h
+++ b/src/ASTUtils.h
@@ -27,8 +27,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 
 typedef std::unordered_map<std::string, const ASTDeductionTarget*> TargetTable;
+
+typedef std::unordered_set<std::string> SymbolSet;
 
 class ASTUtils
 {

--- a/src/SemanticAnalyzer.cpp
+++ b/src/SemanticAnalyzer.cpp
@@ -70,12 +70,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // -----------------------------------------------------------------------------
 
 struct InferenceDefnContext
-  {
-    const std::string& name;
-    SymbolSet symbolSet;
-    TargetTable targetTbl;
-  };
-
+{
+  const std::string& name;
+  SymbolSet symbolSet;
+  TargetTable targetTbl;
+};
 
 // -----------------------------------------------------------------------------
 

--- a/src/SemanticAnalyzer.cpp
+++ b/src/SemanticAnalyzer.cpp
@@ -69,6 +69,16 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 // -----------------------------------------------------------------------------
 
+struct InferenceDefnContext
+  {
+    const std::string& name;
+    SymbolSet symbolSet;
+    TargetTable targetTbl;
+  };
+
+
+// -----------------------------------------------------------------------------
+
 SemanticAnalyzer::SemanticAnalyzer()
   : ASTVisitor()
   , _errors()

--- a/src/SemanticAnalyzer.h
+++ b/src/SemanticAnalyzer.h
@@ -58,9 +58,9 @@ public:
   const Options& options() const;
 
 private:
-  virtual bool previsit(const ASTModule&) override;
-  virtual bool previsit(const ASTInferenceGroup&) override;
-  virtual bool previsit(const ASTInferenceDefn&) override;
+  bool previsit(const ASTModule&) override;
+  bool previsit(const ASTInferenceGroup&) override;
+  bool previsit(const ASTInferenceDefn&) override;
 
   bool checkRequiredEnvDefns(const SymbolSet&);
 

--- a/src/SemanticAnalyzer.h
+++ b/src/SemanticAnalyzer.h
@@ -29,14 +29,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include <cstdio>
 #include <string>
-#include <unordered_set>
 #include <vector>
 
 struct InferenceDefnContext;
 
 typedef struct InferenceDefnContext* InferenceDefnContextRef;
-
-typedef std::unordered_set<std::string> SymbolSet;
 
 class SemanticAnalyzer : public ASTVisitor
 {
@@ -65,10 +62,10 @@ private:
   virtual bool previsit(const ASTInferenceGroup&) override;
   virtual bool previsit(const ASTInferenceDefn&) override;
 
-
   bool checkRequiredEnvDefns(const SymbolSet&);
 
-  bool recursivePremiseDefnCheck(const ASTPremiseDefn&, InferenceDefnContextRef);
+  bool recursivePremiseDefnCheck(const ASTPremiseDefn&,
+                                 InferenceDefnContextRef);
 
   template <typename T>
   bool recursivePremiseDefnCheck(const T&, InferenceDefnContextRef);

--- a/src/SemanticAnalyzer.h
+++ b/src/SemanticAnalyzer.h
@@ -32,6 +32,12 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <unordered_set>
 #include <vector>
 
+struct InferenceDefnContext;
+
+typedef struct InferenceDefnContext* InferenceDefnContextRef;
+
+typedef std::unordered_set<std::string> SymbolSet;
+
 class SemanticAnalyzer : public ASTVisitor
 {
 public:
@@ -59,21 +65,13 @@ private:
   virtual bool previsit(const ASTInferenceGroup&) override;
   virtual bool previsit(const ASTInferenceDefn&) override;
 
-  typedef std::unordered_set<std::string> SymbolSet;
-
-  struct InferenceDefnContext
-  {
-    const std::string& name;
-    SymbolSet symbolSet;
-    TargetTable targetTbl;
-  };
 
   bool checkRequiredEnvDefns(const SymbolSet&);
 
-  bool recursivePremiseDefnCheck(const ASTPremiseDefn&, InferenceDefnContext*);
+  bool recursivePremiseDefnCheck(const ASTPremiseDefn&, InferenceDefnContextRef);
 
   template <typename T>
-  bool recursivePremiseDefnCheck(const T&, InferenceDefnContext*);
+  bool recursivePremiseDefnCheck(const T&, InferenceDefnContextRef);
 
 private:
   enum

--- a/src/Synthesizer.cpp
+++ b/src/Synthesizer.cpp
@@ -197,7 +197,7 @@ Synthesizer::Synthesizer(const Options& opts)
 // -----------------------------------------------------------------------------
 
 bool
-Synthesizer::run(const ASTModule& module)
+Synthesizer::run(const ASTModule& module) const
 {
   SynthesizerImpl impl(_opts);
   return impl.run(module);

--- a/src/Synthesizer.h
+++ b/src/Synthesizer.h
@@ -40,7 +40,7 @@ public:
 
   explicit Synthesizer(const Options&);
 
-  bool run(const ASTModule&);
+  bool run(const ASTModule&) const;
 
 private:
   Options _opts;


### PR DESCRIPTION
This patch consists of several minor refinements across class interfaces.

Notable changes:

- Made type definition of `struct InferenceDefnContext` private in `SemanticAnalyzer.cpp`.
- Made `Synthesize::run(...)` member function const.