### PR TITLE
Redesign compiler error and warning types - Part 2

### DIFF
--- a/src/CompilerError.cpp
+++ b/src/CompilerError.cpp
@@ -28,13 +28,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 std::string
 CompilerError::message() const
 {
-// TODO: Integrate compiler error code
-#if 0
   char buf[2048] = {0};
-  snprintf(buf, sizeof(buf), "%s [%s - %s]", msg.c_str(), categoryName.c_str(),
-           categoryMessage.c_str());
+  snprintf(buf, sizeof(buf), "%s [%s - %s]", msg.c_str(), categoryName,
+           categoryMessage);
   return buf;
-#else
-  return msg;
-#endif
 }

--- a/src/CompilerError.cpp
+++ b/src/CompilerError.cpp
@@ -29,7 +29,7 @@ std::string
 CompilerError::message() const
 {
   char buf[2048] = {0};
-  snprintf(buf, sizeof(buf), "%s [%s - %s]", msg.c_str(), categoryName,
-           categoryMessage);
+  snprintf(buf, sizeof(buf), "%s [%s - %s (code %u)]", msg.c_str(),
+           categoryName, categoryMessage, code);
   return buf;
 }

--- a/src/ProgramDriver.cpp
+++ b/src/ProgramDriver.cpp
@@ -100,15 +100,11 @@ ProgramDriver::run(int argc, char** argv)
   Synthesizer::Options synthesisOpts{.useException = false,
                                      .outputPath = cmdlOpts.outputPath};
   Synthesizer synthesizer(synthesisOpts);
-  res = synthesizer.run(module);
+  res = synthesizer.run(module, &errorPrinter);
   if (!res) {
     if (!cmdlOpts.silent) {
-      char buf[2048] = {0};
-      snprintf(buf, sizeof(buf), "Error: Failed to synthesize output to: %s",
-               cmdlOpts.outputPath.c_str());
-      errorPrinter.printError(
-          SynthesisErrorCategory::CreateCompilerErrorWithTypeAndMessage(
-              CompilerError::Type::Error, 0 /** code **/, buf));
+      fprintf(stderr, "Error: Failed to synthesize output to: %s\n",
+              cmdlOpts.outputPath.c_str());
     }
     return EXIT_FAILURE;
   }

--- a/src/SemanticAnalysisErrorCategory.h
+++ b/src/SemanticAnalysisErrorCategory.h
@@ -25,6 +25,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "CompilerErrorCategory.h"
 
+#include <cassert>
+
 struct SemanticAnalysisErrorCategory
   : public CompilerErrorCategory<SemanticAnalysisErrorCategory>
 {
@@ -35,7 +37,29 @@ struct SemanticAnalysisErrorCategory
 
   static const char* CategoryMessageByCode(CompilerError::Code code)
   {
-    // TODO: Integrate compiler error code
-    return "SemanticAnalysisErrorCategory::message() TBD";
-  }
-};
+    switch (code) {
+      case kSemanticAnalysisDuplicateInferenceGroupIdentifier:
+        return "duplicate infernece group identifier";
+      case kSemanticAnalysisDuplicateInferenceDefnIdentifier:
+        return "duplicate inference definition identifier";
+      case kSemanticAnalysisDuplicateEnvironmentDefnField:
+        return "duplicate environment definition field";
+      case kSemanticAnalysisDuplicateGlobalDefinition:
+        return "duplicate global symbol definition";
+      case kSemanticAnalysisDuplicateArgumentIdentifier:
+        return "duplicate argument identifier";
+      case kSemanticAnalysisInvalidTargetType:
+        return "invalid target type";
+      case kSemanticAnalysisMissingRequiredEnvironmentDefnField:
+        return "missing required environment definition field";
+      case kSemanticAnalysisUnknownSymbol:
+        return "unknown symbol";
+      case kSemanticAnalysisIncompatibleTargetType:
+        return "incompatible target type";
+      case kSemanticAnalysisUnknownPremiseDefn:
+        return "unknown premise definition";
+      default:
+        assert(0 && "Unrecognized error code");
+        return "unrecognized error code";
+    }
+  };

--- a/src/SemanticAnalysisErrorCategory.h
+++ b/src/SemanticAnalysisErrorCategory.h
@@ -24,6 +24,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #pragma once
 
 #include "CompilerErrorCategory.h"
+#include "SemanticAnalysisErrorCodes.h"
 
 #include <cassert>
 

--- a/src/SemanticAnalysisErrorCategory.h
+++ b/src/SemanticAnalysisErrorCategory.h
@@ -62,4 +62,5 @@ struct SemanticAnalysisErrorCategory
         assert(0 && "Unrecognized error code");
         return "unrecognized error code";
     }
-  };
+  }
+};

--- a/src/SemanticAnalysisErrorCategory.h
+++ b/src/SemanticAnalysisErrorCategory.h
@@ -39,25 +39,25 @@ struct SemanticAnalysisErrorCategory
   static const char* CategoryMessageByCode(CompilerError::Code code)
   {
     switch (code) {
-      case kSemanticAnalysisDuplicateInferenceGroupIdentifier:
+      case kSemanticAnalysisDuplicateInferenceGroupIdentifierError:
         return "duplicate infernece group identifier";
-      case kSemanticAnalysisDuplicateInferenceDefnIdentifier:
+      case kSemanticAnalysisDuplicateInferenceDefnIdentifierError:
         return "duplicate inference definition identifier";
-      case kSemanticAnalysisDuplicateEnvironmentDefnField:
+      case kSemanticAnalysisDuplicateEnvironmentDefnFieldError:
         return "duplicate environment definition field";
-      case kSemanticAnalysisDuplicateGlobalDefinition:
+      case kSemanticAnalysisDuplicateGlobalDefinitionError:
         return "duplicate global symbol definition";
-      case kSemanticAnalysisDuplicateArgumentIdentifier:
+      case kSemanticAnalysisDuplicateArgumentIdentifierError:
         return "duplicate argument identifier";
-      case kSemanticAnalysisInvalidTargetType:
+      case kSemanticAnalysisInvalidTargetTypeError:
         return "invalid target type";
-      case kSemanticAnalysisMissingRequiredEnvironmentDefnField:
+      case kSemanticAnalysisMissingRequiredEnvironmentDefnFieldError:
         return "missing required environment definition field";
-      case kSemanticAnalysisUnknownSymbol:
+      case kSemanticAnalysisUnknownSymbolError:
         return "unknown symbol";
-      case kSemanticAnalysisIncompatibleTargetType:
+      case kSemanticAnalysisIncompatibleTargetTypeError:
         return "incompatible target type";
-      case kSemanticAnalysisUnknownPremiseDefn:
+      case kSemanticAnalysisUnknownPremiseDefnError:
         return "unknown premise definition";
       default:
         assert(0 && "Unrecognized error code");

--- a/src/SemanticAnalysisErrorCodes.h
+++ b/src/SemanticAnalysisErrorCodes.h
@@ -27,7 +27,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 enum SemanticAnalysisErrorCodes : uint32_t
 {
-  kSemanticAnalysisDuplicateInferenceGroupIdentifier = 0x01,
+  kSemanticAnalysisDuplicateInferenceGroupIdentifier = 16,
   kSemanticAnalysisDuplicateInferenceDefnIdentifier,
   kSemanticAnalysisDuplicateEnvironmentDefnField,
   kSemanticAnalysisDuplicateGlobalDefinition,

--- a/src/SemanticAnalysisErrorCodes.h
+++ b/src/SemanticAnalysisErrorCodes.h
@@ -27,14 +27,14 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 enum SemanticAnalysisErrorCodes : uint32_t
 {
-  kSemanticAnalysisDuplicateInferenceGroupIdentifier = 16,
-  kSemanticAnalysisDuplicateInferenceDefnIdentifier,
-  kSemanticAnalysisDuplicateEnvironmentDefnField,
-  kSemanticAnalysisDuplicateGlobalDefinition,
-  kSemanticAnalysisDuplicateArgumentIdentifier,
-  kSemanticAnalysisInvalidTargetType,
-  kSemanticAnalysisMissingRequiredEnvironmentDefnField,
-  kSemanticAnalysisUnknownSymbol,
-  kSemanticAnalysisIncompatibleTargetType,
-  kSemanticAnalysisUnknownPremiseDefn,
+  kSemanticAnalysisDuplicateInferenceGroupIdentifierError = 16,
+  kSemanticAnalysisDuplicateInferenceDefnIdentifierError,
+  kSemanticAnalysisDuplicateEnvironmentDefnFieldError,
+  kSemanticAnalysisDuplicateGlobalDefinitionError,
+  kSemanticAnalysisDuplicateArgumentIdentifierError,
+  kSemanticAnalysisInvalidTargetTypeError,
+  kSemanticAnalysisMissingRequiredEnvironmentDefnFieldError,
+  kSemanticAnalysisUnknownSymbolError,
+  kSemanticAnalysisIncompatibleTargetTypeError,
+  kSemanticAnalysisUnknownPremiseDefnError,
 };

--- a/src/SemanticAnalysisErrorCodes.h
+++ b/src/SemanticAnalysisErrorCodes.h
@@ -1,0 +1,40 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2020 Tomiko
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*******************************************************************************/
+
+#pragma once
+
+#include <cstdint>
+
+enum SemanticAnalysisErrorCodes : uint32_t
+{
+  kSemanticAnalysisDuplicateInferenceGroupIdentifier = 0x01,
+  kSemanticAnalysisDuplicateInferenceDefnIdentifier,
+  kSemanticAnalysisDuplicateEnvironmentDefnField,
+  kSemanticAnalysisDuplicateGlobalDefinition,
+  kSemanticAnalysisDuplicateArgumentIdentifier,
+  kSemanticAnalysisInvalidTargetType,
+  kSemanticAnalysisMissingRequiredEnvironmentDefnField,
+  kSemanticAnalysisUnknownSymbol,
+  kSemanticAnalysisIncompatibleTargetType,
+  kSemanticAnalysisUnknownPremiseDefn,
+};

--- a/src/SemanticAnalyzer.cpp
+++ b/src/SemanticAnalyzer.cpp
@@ -131,7 +131,7 @@ SemanticAnalyzer::previsit(const ASTModule& module)
   for (const auto& inferenceGroup : module.inferenceGroups()) {
     const auto& name = inferenceGroup.name();
     if (nameSet.count(name)) {
-      ON_ERROR(kSemanticAnalysisDuplicateInferenceGroupIdentifier,
+      ON_ERROR(kSemanticAnalysisDuplicateInferenceGroupIdentifierError,
                "Found multiple inference group with name \"%s\".",
                name.c_str());
     } else {
@@ -156,7 +156,7 @@ SemanticAnalyzer::previsit(const ASTInferenceGroup& inferenceGroup)
     for (const auto& environmentDefn : inferenceGroup.environmentDefns()) {
       const auto& field = environmentDefn.field();
       if (nameSet.count(field)) {
-        ON_WARNING(kSemanticAnalysisDuplicateEnvironmentDefnField,
+        ON_WARNING(kSemanticAnalysisDuplicateEnvironmentDefnFieldError,
                    "Found repeated environment field \"%s\".", field.c_str());
       } else {
         nameSet.insert(field);
@@ -174,7 +174,7 @@ SemanticAnalyzer::previsit(const ASTInferenceGroup& inferenceGroup)
     for (const auto& inferenceDefn : inferenceGroup.inferenceDefns()) {
       const auto& name = inferenceDefn.name();
       if (nameSet.count(name)) {
-        ON_ERROR(kSemanticAnalysisDuplicateInferenceDefnIdentifier,
+        ON_ERROR(kSemanticAnalysisDuplicateInferenceDefnIdentifierError,
                  "Found multiple inference definition with name \"%s\".",
                  name.c_str());
       } else {
@@ -202,7 +202,7 @@ SemanticAnalyzer::previsit(const ASTInferenceDefn& inferenceDefn)
       const auto& name = decl.name();
       if (context.symbolSet.count(name)) {
         ON_WARNING(
-            kSemanticAnalysisDuplicateGlobalDefinition,
+            kSemanticAnalysisDuplicateGlobalDefinitionError,
             "Found duplicate symbol (global declaration) with name \"%s\".",
             name.c_str());
       } else {
@@ -216,7 +216,7 @@ SemanticAnalyzer::previsit(const ASTInferenceDefn& inferenceDefn)
     for (const auto& argument : inferenceDefn.arguments()) {
       const auto& name = argument.name();
       if (context.symbolSet.count(name)) {
-        ON_ERROR(kSemanticAnalysisDuplicateArgumentIdentifier,
+        ON_ERROR(kSemanticAnalysisDuplicateArgumentIdentifierError,
                  "Found duplicate symbol (argument) with name \"%s\".",
                  name.c_str());
       } else {
@@ -239,7 +239,7 @@ SemanticAnalyzer::previsit(const ASTInferenceDefn& inferenceDefn)
     const auto& proposition = inferenceDefn.propositionDefn();
     if (!ASTUtils::HasCompatibleTargetInTable(proposition.target(),
                                               context.targetTbl)) {
-      ON_ERROR(kSemanticAnalysisInvalidTargetType,
+      ON_ERROR(kSemanticAnalysisInvalidTargetTypeError,
                "Invalid proposition target type in inference \"%s\".",
                context.name.c_str());
     }
@@ -264,7 +264,7 @@ SemanticAnalyzer::checkRequiredEnvDefns(const SymbolSet& envDefns)
 
   for (auto defn : mandatoryEnvDefns) {
     if (envDefns.count(defn) == 0) {
-      ON_ERROR(kSemanticAnalysisMissingRequiredEnvironmentDefnField,
+      ON_ERROR(kSemanticAnalysisMissingRequiredEnvironmentDefnFieldError,
                "Missing required environment definition field \"%s\".", defn);
     }
   }
@@ -286,7 +286,7 @@ SemanticAnalyzer::recursivePremiseDefnCheck(const ASTInferencePremiseDefn& defn,
     const auto& source = defn.source();
     const auto& sourceRoot = ASTUtils::GetRootOfASTIdentifiable(source);
     if (context->symbolSet.count(sourceRoot) == 0) {
-      ON_ERROR(kSemanticAnalysisUnknownSymbol,
+      ON_ERROR(kSemanticAnalysisUnknownSymbolError,
                "Unknown symbol \"%s\" used in inference \"%s\".",
                sourceRoot.c_str(), context->name.c_str());
     }
@@ -296,7 +296,7 @@ SemanticAnalyzer::recursivePremiseDefnCheck(const ASTInferencePremiseDefn& defn,
   {
     const auto& target = defn.deductionTarget();
     if (ASTUtils::HasIncompatibleTargetInTable(target, context->targetTbl)) {
-      ON_ERROR(kSemanticAnalysisIncompatibleTargetType,
+      ON_ERROR(kSemanticAnalysisIncompatibleTargetTypeError,
                "Found duplicate and incompatible target in inference \"%s\".",
                context->name.c_str());
     }
@@ -329,7 +329,7 @@ SemanticAnalyzer::recursivePremiseDefnCheck(
   const auto& rhs = defn.rhs();
 
   if (!ASTUtils::AreTargetsCompatible(lhs, rhs)) {
-    ON_ERROR(kSemanticAnalysisIncompatibleTargetType,
+    ON_ERROR(kSemanticAnalysisIncompatibleTargetTypeError,
              "Incompatible targets in expression in inference \"%s\".",
              context->name.c_str());
   }
@@ -340,12 +340,12 @@ SemanticAnalyzer::recursivePremiseDefnCheck(
       const auto& rangeClause = defn.rangeClause();
       const auto& target = rangeClause.deductionTarget();
       if (target.isType<ASTDeductionTargetSingular>()) {
-        ON_ERROR(kSemanticAnalysisInvalidTargetType,
+        ON_ERROR(kSemanticAnalysisInvalidTargetTypeError,
                  "Invalid target in range clause in inference \"%s\".",
                  context->name.c_str());
       }
       if (!ASTUtils::HasCompatibleTargetInTable(target, context->targetTbl)) {
-        ON_ERROR(kSemanticAnalysisInvalidTargetType,
+        ON_ERROR(kSemanticAnalysisInvalidTargetTypeError,
                  "Invalid target in range clause in inference \"%s\".",
                  context->name.c_str());
       }
@@ -372,7 +372,7 @@ SemanticAnalyzer::recursivePremiseDefnCheck(const ASTPremiseDefn& premiseDefn,
     const auto& defnValue = premiseDefn.value<ASTInferenceEqualityDefn>();
     RETURN_ON_FAILURE(recursivePremiseDefnCheck(defnValue, context));
   } else {
-    ON_ERROR(kSemanticAnalysisUnknownPremiseDefn,
+    ON_ERROR(kSemanticAnalysisUnknownPremiseDefnError,
              "Found unknown type of premise definition in inference \"%s\".",
              inferenceDefnName);
   }

--- a/src/SemanticAnalyzer.cpp
+++ b/src/SemanticAnalyzer.cpp
@@ -23,8 +23,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "SemanticAnalyzer.h"
 
-#include "SemanticAnalysisErrorCodes.h"
 #include "ASTUtils.h"
+#include "SemanticAnalysisErrorCodes.h"
 #include "ast.h"
 #include "format_defn.h"
 
@@ -40,9 +40,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 // -----------------------------------------------------------------------------
 
-#define ON_WARNING(code, msg, ...)                                                   \
+#define ON_WARNING(code, msg, ...)                                             \
   do {                                                                         \
-    addWarning(code, (msg), __VA_ARGS__);                                            \
+    addWarning(code, (msg), __VA_ARGS__);                                      \
     if (_opts.warningsAsErrors) {                                              \
       res = false;                                                             \
       if (_opts.bailOnFirstError) {                                            \
@@ -53,10 +53,10 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 // -----------------------------------------------------------------------------
 
-#define ON_ERROR(code, msg, ...)                                                     \
+#define ON_ERROR(code, msg, ...)                                               \
   do {                                                                         \
     res = false;                                                               \
-    addError(code, (msg), __VA_ARGS__);                                              \
+    addError(code, (msg), __VA_ARGS__);                                        \
     if (_opts.bailOnFirstError) {                                              \
       return res;                                                              \
     }                                                                          \
@@ -131,7 +131,8 @@ SemanticAnalyzer::previsit(const ASTModule& module)
   for (const auto& inferenceGroup : module.inferenceGroups()) {
     const auto& name = inferenceGroup.name();
     if (nameSet.count(name)) {
-      ON_ERROR(kSemanticAnalysisDuplicateInferenceGroupIdentifier, "Found multiple inference group with name \"%s\".",
+      ON_ERROR(kSemanticAnalysisDuplicateInferenceGroupIdentifier,
+               "Found multiple inference group with name \"%s\".",
                name.c_str());
     } else {
       nameSet.insert(name);
@@ -155,7 +156,8 @@ SemanticAnalyzer::previsit(const ASTInferenceGroup& inferenceGroup)
     for (const auto& environmentDefn : inferenceGroup.environmentDefns()) {
       const auto& field = environmentDefn.field();
       if (nameSet.count(field)) {
-        ON_WARNING(kSemanticAnalysisDuplicateEnvironmentDefnField, "Found repeated environment field \"%s\".", field.c_str());
+        ON_WARNING(kSemanticAnalysisDuplicateEnvironmentDefnField,
+                   "Found repeated environment field \"%s\".", field.c_str());
       } else {
         nameSet.insert(field);
       }
@@ -172,7 +174,8 @@ SemanticAnalyzer::previsit(const ASTInferenceGroup& inferenceGroup)
     for (const auto& inferenceDefn : inferenceGroup.inferenceDefns()) {
       const auto& name = inferenceDefn.name();
       if (nameSet.count(name)) {
-        ON_ERROR(kSemanticAnalysisDuplicateInferenceDefnIdentifier, "Found multiple inference definition with name \"%s\".",
+        ON_ERROR(kSemanticAnalysisDuplicateInferenceDefnIdentifier,
+                 "Found multiple inference definition with name \"%s\".",
                  name.c_str());
       } else {
         nameSet.insert(name);
@@ -198,7 +201,8 @@ SemanticAnalyzer::previsit(const ASTInferenceDefn& inferenceDefn)
     for (const auto& decl : inferenceDefn.globalDecls()) {
       const auto& name = decl.name();
       if (context.symbolSet.count(name)) {
-        ON_WARNING(kSemanticAnalysisDuplicateGlobalDefinition,
+        ON_WARNING(
+            kSemanticAnalysisDuplicateGlobalDefinition,
             "Found duplicate symbol (global declaration) with name \"%s\".",
             name.c_str());
       } else {
@@ -212,8 +216,8 @@ SemanticAnalyzer::previsit(const ASTInferenceDefn& inferenceDefn)
     for (const auto& argument : inferenceDefn.arguments()) {
       const auto& name = argument.name();
       if (context.symbolSet.count(name)) {
-        ON_ERROR(  kSemanticAnalysisDuplicateArgumentIdentifier,
-"Found duplicate symbol (argument) with name \"%s\".",
+        ON_ERROR(kSemanticAnalysisDuplicateArgumentIdentifier,
+                 "Found duplicate symbol (argument) with name \"%s\".",
                  name.c_str());
       } else {
         context.symbolSet.insert(name);
@@ -235,7 +239,8 @@ SemanticAnalyzer::previsit(const ASTInferenceDefn& inferenceDefn)
     const auto& proposition = inferenceDefn.propositionDefn();
     if (!ASTUtils::HasCompatibleTargetInTable(proposition.target(),
                                               context.targetTbl)) {
-      ON_ERROR(kSemanticAnalysisInvalidTargetType, "Invalid proposition target type in inference \"%s\".",
+      ON_ERROR(kSemanticAnalysisInvalidTargetType,
+               "Invalid proposition target type in inference \"%s\".",
                context.name.c_str());
     }
   }
@@ -259,7 +264,8 @@ SemanticAnalyzer::checkRequiredEnvDefns(const SymbolSet& envDefns)
 
   for (auto defn : mandatoryEnvDefns) {
     if (envDefns.count(defn) == 0) {
-      ON_ERROR(  kSemanticAnalysisMissingRequiredEnvironmentDefnField, "Missing required environment definition field \"%s\".", defn);
+      ON_ERROR(kSemanticAnalysisMissingRequiredEnvironmentDefnField,
+               "Missing required environment definition field \"%s\".", defn);
     }
   }
 
@@ -280,7 +286,8 @@ SemanticAnalyzer::recursivePremiseDefnCheck(const ASTInferencePremiseDefn& defn,
     const auto& source = defn.source();
     const auto& sourceRoot = ASTUtils::GetRootOfASTIdentifiable(source);
     if (context->symbolSet.count(sourceRoot) == 0) {
-      ON_ERROR(  kSemanticAnalysisUnknownSymbol,"Unknown symbol \"%s\" used in inference \"%s\".",
+      ON_ERROR(kSemanticAnalysisUnknownSymbol,
+               "Unknown symbol \"%s\" used in inference \"%s\".",
                sourceRoot.c_str(), context->name.c_str());
     }
   }
@@ -289,7 +296,8 @@ SemanticAnalyzer::recursivePremiseDefnCheck(const ASTInferencePremiseDefn& defn,
   {
     const auto& target = defn.deductionTarget();
     if (ASTUtils::HasIncompatibleTargetInTable(target, context->targetTbl)) {
-      ON_ERROR(kSemanticAnalysisIncompatibleTargetType,"Found duplicate and incompatible target in inference \"%s\".",
+      ON_ERROR(kSemanticAnalysisIncompatibleTargetType,
+               "Found duplicate and incompatible target in inference \"%s\".",
                context->name.c_str());
     }
     ASTUtils::AddTargetToTable(target, &context->targetTbl);
@@ -321,7 +329,8 @@ SemanticAnalyzer::recursivePremiseDefnCheck(
   const auto& rhs = defn.rhs();
 
   if (!ASTUtils::AreTargetsCompatible(lhs, rhs)) {
-    ON_ERROR(kSemanticAnalysisIncompatibleTargetType,"Incompatible targets in expression in inference \"%s\".",
+    ON_ERROR(kSemanticAnalysisIncompatibleTargetType,
+             "Incompatible targets in expression in inference \"%s\".",
              context->name.c_str());
   }
 
@@ -331,11 +340,13 @@ SemanticAnalyzer::recursivePremiseDefnCheck(
       const auto& rangeClause = defn.rangeClause();
       const auto& target = rangeClause.deductionTarget();
       if (target.isType<ASTDeductionTargetSingular>()) {
-        ON_ERROR(  kSemanticAnalysisInvalidTargetType,"Invalid target in range clause in inference \"%s\".",
+        ON_ERROR(kSemanticAnalysisInvalidTargetType,
+                 "Invalid target in range clause in inference \"%s\".",
                  context->name.c_str());
       }
       if (!ASTUtils::HasCompatibleTargetInTable(target, context->targetTbl)) {
-        ON_ERROR(  kSemanticAnalysisInvalidTargetType,"Invalid target in range clause in inference \"%s\".",
+        ON_ERROR(kSemanticAnalysisInvalidTargetType,
+                 "Invalid target in range clause in inference \"%s\".",
                  context->name.c_str());
       }
     }
@@ -361,7 +372,8 @@ SemanticAnalyzer::recursivePremiseDefnCheck(const ASTPremiseDefn& premiseDefn,
     const auto& defnValue = premiseDefn.value<ASTInferenceEqualityDefn>();
     RETURN_ON_FAILURE(recursivePremiseDefnCheck(defnValue, context));
   } else {
-    ON_ERROR(  kSemanticAnalysisUnknownPremiseDefn,"Found unknown type of premise definition in inference \"%s\".",
+    ON_ERROR(kSemanticAnalysisUnknownPremiseDefn,
+             "Found unknown type of premise definition in inference \"%s\".",
              inferenceDefnName);
   }
 

--- a/src/SemanticAnalyzer.h
+++ b/src/SemanticAnalyzer.h
@@ -76,10 +76,10 @@ private:
   };
 
   template <typename U, typename... Args>
-  void addWarning(const U& msg, Args... args)
+  void addWarning(CompilerError::Code code, const U& msg, Args... args)
   {
     if (_opts.warningsAsErrors) {
-      addError(msg, args...);
+      addError(code, msg, args...);
     } else {
       char buffer[MAX_MSG_LEN] = {0};
       snprintf(buffer, sizeof(buffer), msg, args...);
@@ -87,20 +87,20 @@ private:
         _errorPrinter->printError(
             SemanticAnalysisErrorCategory::
                 CreateCompilerErrorWithTypeAndMessage(
-                    CompilerError::Type::Warning, 0 /** code **/, buffer));
+                    CompilerError::Type::Warning, code, buffer));
       }
     }
   }
 
   template <typename U, typename... Args>
-  void addError(const U& msg, Args... args)
+  void addError(CompilerError::Code code, const U& msg, Args... args)
   {
     char buffer[MAX_MSG_LEN] = {0};
     snprintf(buffer, sizeof(buffer), msg, args...);
     if (_errorPrinter) {
       _errorPrinter->printError(
           SemanticAnalysisErrorCategory::CreateCompilerErrorWithTypeAndMessage(
-              CompilerError::Type::Error, 0 /** code **/, buffer));
+              CompilerError::Type::Error, code, buffer));
     }
   }
 

--- a/src/SynthesisErrorCodes.h
+++ b/src/SynthesisErrorCodes.h
@@ -23,27 +23,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #pragma once
 
-#include "CompilerErrorCategory.h"
-#include "SynthesisErrorCodes.h"
+#include <cstdint>
 
-#include <cassert>
-
-struct SynthesisErrorCategory
-  : public CompilerErrorCategory<SynthesisErrorCategory>
+enum SynthesisErrorCodes : uint32_t
 {
-  static const char* CategoryName()
-  {
-    return "synthesis error";
-  }
-
-  static const char* CategoryMessageByCode(CompilerError::Code code)
-  {
-    switch (code) {
-      case kSynthesisInvalidOutputError:
-        return "invalid output";
-      default:
-        assert(0 && "Unrecognized error code");
-        return "unrecognized error code";
-    }
-  }
+  kSynthesisInvalidOutputError = 0x01
 };

--- a/src/SynthesisErrorCodes.h
+++ b/src/SynthesisErrorCodes.h
@@ -27,5 +27,5 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 enum SynthesisErrorCodes : uint32_t
 {
-  kSynthesisInvalidOutputError = 0x01
+  kSynthesisInvalidOutputError = 8
 };

--- a/src/Synthesizer.h
+++ b/src/Synthesizer.h
@@ -27,6 +27,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include <string>
 
+struct CompilerErrorPrinter;
+
 class Synthesizer
 {
 public:
@@ -40,7 +42,7 @@ public:
 
   explicit Synthesizer(const Options&);
 
-  bool run(const ASTModule&) const;
+  bool run(const ASTModule&, CompilerErrorPrinter* = nullptr) const;
 
 private:
   Options _opts;

--- a/src/parser/ParserDriver.h
+++ b/src/parser/ParserDriver.h
@@ -103,7 +103,7 @@ public:
   void setCompilerErrorPrinter(CompilerErrorPrinter*);
 
 private:
-  void handleErrorWithMessage(const char*);
+  void handleErrorWithMessageAndCode(const char*, CompilerError::Code);
 
 private:
   Options _opts;

--- a/src/parser/ParserErrorCategory.h
+++ b/src/parser/ParserErrorCategory.h
@@ -24,6 +24,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #pragma once
 
 #include "../CompilerErrorCategory.h"
+#include "ParserErrorCodes.h"
+
+#include <cassert>
 
 struct ParserErrorCategory : public CompilerErrorCategory<ParserErrorCategory>
 {
@@ -34,7 +37,13 @@ struct ParserErrorCategory : public CompilerErrorCategory<ParserErrorCategory>
 
   static const char* CategoryMessageByCode(CompilerError::Code code)
   {
-    // TODO: Integrate compiler error code
-    return "ParserErrorCategory::message() TBD";
+    switch (code) {
+      case kParserBadInputError:
+        return "bad input";
+      case kParserInvalidSyntaxError:
+        return "invalid syntax";
+      default:
+        assert(0 && "Unrecognized error code");
+    }
   }
 };

--- a/src/parser/ParserErrorCategory.h
+++ b/src/parser/ParserErrorCategory.h
@@ -44,6 +44,7 @@ struct ParserErrorCategory : public CompilerErrorCategory<ParserErrorCategory>
         return "invalid syntax";
       default:
         assert(0 && "Unrecognized error code");
+        return "unrecognized error code";
     }
   }
 };

--- a/src/parser/ParserErrorCodes.h
+++ b/src/parser/ParserErrorCodes.h
@@ -1,3 +1,26 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2020 Tomiko
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*******************************************************************************/
+
 #pragma once
 
 #include <cstdint>

--- a/src/parser/ParserErrorCodes.h
+++ b/src/parser/ParserErrorCodes.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <cstdint>
+
+enum ParserErrors : uint32_t
+{
+  kParserBadInputError,
+  kParserInvalidSyntaxError
+};

--- a/src/parser/ParserErrorCodes.h
+++ b/src/parser/ParserErrorCodes.h
@@ -27,6 +27,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 enum ParserErrors : uint32_t
 {
-  kParserBadInputError,
+  kParserBadInputError = 4,
   kParserInvalidSyntaxError
 };

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -34,6 +34,14 @@ import sys
 
 ## -----------------------------------------------------------------------------
 
+EXIT_SUCCESS = 0
+
+## -----------------------------------------------------------------------------
+
+EXIT_FAILURE = 1
+
+## -----------------------------------------------------------------------------
+
 JSON_EXT = '.json'
 PROG_TITLE = 'Snowlake integration test.'
 SNOWLAKE_COMPILER_EXECUTABLE = 'snowlakec'
@@ -162,7 +170,7 @@ class TestRunner(object):
         self.logger.addHandler(console_handler)
 
     def run(self):
-        self.__run()
+        return self.__run()
 
     def __run(self):
         print()
@@ -191,8 +199,10 @@ class TestRunner(object):
 
         if success_count == total_count:
             self.__log_success('- SUCCESS -')
+            return EXIT_SUCCESS
         else:
             self.__log_failure('- FAIL -')
+            return EXIT_FAILURE
 
     def __run_test_case(self, json_filepath):
         try:
@@ -359,7 +369,7 @@ def main():
         print(executable_invoke_name)
 
     runner = TestRunner(input_path, executable_invoke_name, args)
-    runner.run()
+    sys.exit(runner.run())
 
 
 if __name__ == '__main__':

--- a/tests/test_duplicate_groups.json
+++ b/tests/test_duplicate_groups.json
@@ -3,6 +3,6 @@
   "input_path": "./fixtures/duplicate_groups.sl",
   "expected_exit": 1,
   "expected_errors": [
-    "Found multiple inference group with name \"MyGroup\"."
+    "Found multiple inference group with name \"MyGroup\". [semantic analysis error - duplicate infernece group identifier (code 16)]"
   ]
 }

--- a/tests/test_incompatible_array_type_target.json
+++ b/tests/test_incompatible_array_type_target.json
@@ -3,6 +3,6 @@
   "input_path": "./fixtures/incompatible_array_type_target.sl",
   "expected_exit": 1,
   "expected_errors": [
-    "Found duplicate and incompatible target in inference \"MethodStaticDispatch\"."
+    "Found duplicate and incompatible target in inference \"MethodStaticDispatch\". [semantic analysis error - incompatible target type (code 24)]"
   ]
 }

--- a/tests/test_incompatible_targets_in_range_clause.json
+++ b/tests/test_incompatible_targets_in_range_clause.json
@@ -3,7 +3,7 @@
   "input_path": "./fixtures/incompatible_targets_in_range_clause.sl",
   "expected_exit": 1,
   "expected_errors": [
-    "Incompatible targets in expression in inference \"MethodStaticDispatch\".",
-    "Invalid target in range clause in inference \"MethodStaticDispatch\"."
+    "Incompatible targets in expression in inference \"MethodStaticDispatch\". [semantic analysis error - incompatible target type (code 24)]",
+    "Invalid target in range clause in inference \"MethodStaticDispatch\". [semantic analysis error - invalid target type (code 21)]"
   ]
 }

--- a/tests/test_invalid_keyword.json
+++ b/tests/test_invalid_keyword.json
@@ -3,6 +3,6 @@
   "input_path": "./fixtures/invalid_keyword.sl",
   "expected_exit": 1,
   "expected_errors": [
-    "Parser error: syntax error, unexpected IDENTIFIER, expecting KEYWORD_WHILE or SEMICOLON [12.67-68]"
+    "Parser error: syntax error, unexpected IDENTIFIER, expecting KEYWORD_WHILE or SEMICOLON [12.67-68] [parser error - invalid syntax (code 5)]"
   ]
 }

--- a/tests/test_invalid_nested_premise.json
+++ b/tests/test_invalid_nested_premise.json
@@ -3,7 +3,7 @@
   "input_path": "./fixtures/invalid_nested_premise.sl",
   "expected_exit": 1,
   "expected_errors": [
-    "Incompatible targets in expression in inference \"MethodStaticDispatch\".",
-    "Invalid target in range clause in inference \"MethodStaticDispatch\"."
+    "Incompatible targets in expression in inference \"MethodStaticDispatch\". [semantic analysis error - incompatible target type (code 24)]",
+    "Invalid target in range clause in inference \"MethodStaticDispatch\". [semantic analysis error - invalid target type (code 21)]"
   ]
 }

--- a/tests/test_invalid_proposition.json
+++ b/tests/test_invalid_proposition.json
@@ -3,6 +3,6 @@
   "input_path": "./fixtures/invalid_proposition.sl",
   "expected_exit": 1,
   "expected_errors": [
-    "Invalid proposition target type in inference \"MethodStaticDispatch\"."
+    "Invalid proposition target type in inference \"MethodStaticDispatch\". [semantic analysis error - invalid target type (code 21)]"
   ]
 }

--- a/tests/test_invalid_range_clause.json
+++ b/tests/test_invalid_range_clause.json
@@ -3,6 +3,6 @@
   "input_path": "./fixtures/invalid_range_clause.sl",
   "expected_exit": 1,
   "expected_errors": [
-    "Invalid target in range clause in inference \"MethodStaticDispatch\"."
+    "Invalid target in range clause in inference \"MethodStaticDispatch\". [semantic analysis error - invalid target type (code 21)]"
   ]
 }

--- a/tests/test_repeated_target_in_premise.json
+++ b/tests/test_repeated_target_in_premise.json
@@ -3,6 +3,6 @@
   "input_path": "./fixtures/repeated_target_in_premise.sl",
   "expected_exit": 1,
   "expected_errors": [
-    "Found duplicate and incompatible target in inference \"MethodStaticDispatch\"."
+    "Found duplicate and incompatible target in inference \"MethodStaticDispatch\". [semantic analysis error - incompatible target type (code 24)]"
   ]
 }

--- a/tests/test_repeating_symbol.json
+++ b/tests/test_repeating_symbol.json
@@ -3,7 +3,7 @@
   "input_path": "./fixtures/repeating_symbol.sl",
   "expected_exit": 1,
   "expected_errors": [
-    "Found duplicate symbol (argument) with name \"Arg1\".",
-    "Invalid proposition target type in inference \"MyInference\"."
+    "Found duplicate symbol (argument) with name \"Arg1\". [semantic analysis error - duplicate argument identifier (code 20)]",
+    "Invalid proposition target type in inference \"MyInference\". [semantic analysis error - invalid target type (code 21)]"
   ]
 }


### PR DESCRIPTION
This patch is the continuation of the work started in #62 in redesigning the type ecosystem of the compiler error/warning type, as well as a more granular mechanism to structure compiler error code and messages.

Specifically, this patch introduces error codes for each component error category, and integrates them into the compiler error handling and report mechanism. The integration tests are updated to reflect the change.