### PR TITLE
Refine integration test compiler error handling and checking

### DIFF
--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -289,6 +289,10 @@ class TestRunner(object):
         category_message = expected_error['category_message']
         code = expected_error['code']
 
+        ##
+        # Follow the format defined in
+        #   `CompilerError::message()`
+        # in 'src/CompilerError.cpp'
         return '{msg} [{category_name} - {category_message} (code {code})]'.format(
             msg=msg,
             category_name=category_name,

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -277,9 +277,24 @@ class TestRunner(object):
             pedantic=pedantic)
 
         return '\n'.join([
-            '{input_path}: error: {error_msg}'.format(input_path=input_path, error_msg=error_msg)
-            for error_msg in expected_errors
+            '{input_path}: error: {error_msg}'.format(
+                input_path=input_path,
+                error_msg=self.__format_test_case_error_message(expected_error))
+            for expected_error in expected_errors
         ]) + '\n\n' + tail
+
+    def __format_test_case_error_message(self, expected_error):
+        msg = expected_error['msg']
+        category_name = expected_error['category_name']
+        category_message = expected_error['category_message']
+        code = expected_error['code']
+
+        return '{msg} [{category_name} - {category_message} (code {code})]'.format(
+            msg=msg,
+            category_name=category_name,
+            category_message=category_message,
+            code=code
+        )
 
     def __log_msg(self, msg, color=None):
         if color:

--- a/tests/test_duplicate_groups.json
+++ b/tests/test_duplicate_groups.json
@@ -3,6 +3,11 @@
   "input_path": "./fixtures/duplicate_groups.sl",
   "expected_exit": 1,
   "expected_errors": [
-    "Found multiple inference group with name \"MyGroup\". [semantic analysis error - duplicate infernece group identifier (code 16)]"
+    {
+        "msg": "Found multiple inference group with name \"MyGroup\".",
+        "category_name": "semantic analysis error",
+        "category_message": "duplicate infernece group identifier",
+        "code": 16
+    }
   ]
 }

--- a/tests/test_incompatible_array_type_target.json
+++ b/tests/test_incompatible_array_type_target.json
@@ -3,6 +3,11 @@
   "input_path": "./fixtures/incompatible_array_type_target.sl",
   "expected_exit": 1,
   "expected_errors": [
-    "Found duplicate and incompatible target in inference \"MethodStaticDispatch\". [semantic analysis error - incompatible target type (code 24)]"
+    {
+        "msg": "Found duplicate and incompatible target in inference \"MethodStaticDispatch\".",
+        "category_name": "semantic analysis error",
+        "category_message": "incompatible target type",
+        "code": 24
+    }
   ]
 }

--- a/tests/test_incompatible_targets_in_range_clause.json
+++ b/tests/test_incompatible_targets_in_range_clause.json
@@ -3,7 +3,17 @@
   "input_path": "./fixtures/incompatible_targets_in_range_clause.sl",
   "expected_exit": 1,
   "expected_errors": [
-    "Incompatible targets in expression in inference \"MethodStaticDispatch\". [semantic analysis error - incompatible target type (code 24)]",
-    "Invalid target in range clause in inference \"MethodStaticDispatch\". [semantic analysis error - invalid target type (code 21)]"
+    {
+        "msg": "Incompatible targets in expression in inference \"MethodStaticDispatch\".",
+        "category_name": "semantic analysis error",
+        "category_message": "incompatible target type",
+        "code": 24
+    },
+    {
+        "msg": "Invalid target in range clause in inference \"MethodStaticDispatch\".",
+        "category_name": "semantic analysis error",
+        "category_message": "invalid target type",
+        "code": 21
+    }
   ]
 }

--- a/tests/test_invalid_keyword.json
+++ b/tests/test_invalid_keyword.json
@@ -3,6 +3,11 @@
   "input_path": "./fixtures/invalid_keyword.sl",
   "expected_exit": 1,
   "expected_errors": [
-    "Parser error: syntax error, unexpected IDENTIFIER, expecting KEYWORD_WHILE or SEMICOLON [12.67-68] [parser error - invalid syntax (code 5)]"
+    {
+        "msg": "Parser error: syntax error, unexpected IDENTIFIER, expecting KEYWORD_WHILE or SEMICOLON [12.67-68]",
+        "category_name": "parser error",
+        "category_message": "invalid syntax",
+        "code": 5
+    }
   ]
 }

--- a/tests/test_invalid_nested_premise.json
+++ b/tests/test_invalid_nested_premise.json
@@ -3,7 +3,17 @@
   "input_path": "./fixtures/invalid_nested_premise.sl",
   "expected_exit": 1,
   "expected_errors": [
-    "Incompatible targets in expression in inference \"MethodStaticDispatch\". [semantic analysis error - incompatible target type (code 24)]",
-    "Invalid target in range clause in inference \"MethodStaticDispatch\". [semantic analysis error - invalid target type (code 21)]"
+    {
+        "msg": "Incompatible targets in expression in inference \"MethodStaticDispatch\".",
+        "category_name": "semantic analysis error",
+        "category_message": "incompatible target type",
+        "code": 24
+    },
+    {
+        "msg": "Invalid target in range clause in inference \"MethodStaticDispatch\".",
+        "category_name": "semantic analysis error",
+        "category_message": "invalid target type",
+        "code": 21
+    }
   ]
 }

--- a/tests/test_invalid_proposition.json
+++ b/tests/test_invalid_proposition.json
@@ -3,6 +3,11 @@
   "input_path": "./fixtures/invalid_proposition.sl",
   "expected_exit": 1,
   "expected_errors": [
-    "Invalid proposition target type in inference \"MethodStaticDispatch\". [semantic analysis error - invalid target type (code 21)]"
+    {
+        "msg": "Invalid proposition target type in inference \"MethodStaticDispatch\".",
+        "category_name": "semantic analysis error",
+        "category_message": "invalid target type",
+        "code": 21
+    }
   ]
 }

--- a/tests/test_invalid_range_clause.json
+++ b/tests/test_invalid_range_clause.json
@@ -3,6 +3,11 @@
   "input_path": "./fixtures/invalid_range_clause.sl",
   "expected_exit": 1,
   "expected_errors": [
-    "Invalid target in range clause in inference \"MethodStaticDispatch\". [semantic analysis error - invalid target type (code 21)]"
+    {
+        "msg": "Invalid target in range clause in inference \"MethodStaticDispatch\".",
+        "category_name": "semantic analysis error",
+        "category_message": "invalid target type",
+        "code": 21
+    }
   ]
 }

--- a/tests/test_repeated_target_in_premise.json
+++ b/tests/test_repeated_target_in_premise.json
@@ -3,6 +3,11 @@
   "input_path": "./fixtures/repeated_target_in_premise.sl",
   "expected_exit": 1,
   "expected_errors": [
-    "Found duplicate and incompatible target in inference \"MethodStaticDispatch\". [semantic analysis error - incompatible target type (code 24)]"
+    {
+        "msg": "Found duplicate and incompatible target in inference \"MethodStaticDispatch\".",
+        "category_name": "semantic analysis error",
+        "category_message": "incompatible target type",
+        "code": 24
+    }
   ]
 }

--- a/tests/test_repeating_symbol.json
+++ b/tests/test_repeating_symbol.json
@@ -3,7 +3,17 @@
   "input_path": "./fixtures/repeating_symbol.sl",
   "expected_exit": 1,
   "expected_errors": [
-    "Found duplicate symbol (argument) with name \"Arg1\". [semantic analysis error - duplicate argument identifier (code 20)]",
-    "Invalid proposition target type in inference \"MyInference\". [semantic analysis error - invalid target type (code 21)]"
+    {
+        "msg": "Found duplicate symbol (argument) with name \"Arg1\".",
+        "category_name": "semantic analysis error",
+        "category_message": "duplicate argument identifier",
+        "code": 20
+    },
+    {
+        "msg": "Invalid proposition target type in inference \"MyInference\".",
+        "category_name": "semantic analysis error",
+        "category_message": "invalid target type",
+        "code": 21
+    }
   ]
 }


### PR DESCRIPTION
This patch follows the work done in #62 and #63 by refining the way compiler errors are archived and handled in the integration tests. This change makes it a little easier to maintain the associated expected compiler errors of each integration test case by storing the expected compiler error data in a more structured format.