### PR TITLE
Refactor compiler errors and warnings handling - Part 2

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,6 +36,7 @@ set(sources
     ASTVisitor.cpp
     ASTUtils.cpp
     CompilerError.cpp
+    CompilerErrorHandlerRegistrar.cpp
     SemanticAnalyzer.cpp
     Synthesizer.cpp
     ArgumentParser.cpp

--- a/src/CompilerErrorHandlerRegistrar.cpp
+++ b/src/CompilerErrorHandlerRegistrar.cpp
@@ -23,5 +23,10 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "CompilerErrorHandlerRegistrar.h"
 
+// -----------------------------------------------------------------------------
+
 uint32_t CompilerErrorHandlerRegistrar::_registeredID = 0;
+
 CompilerErrorPrinter* CompilerErrorHandlerRegistrar::_errorPrinter = nullptr;
+
+// -----------------------------------------------------------------------------

--- a/src/CompilerErrorHandlerRegistrar.cpp
+++ b/src/CompilerErrorHandlerRegistrar.cpp
@@ -1,3 +1,26 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2020 Tomiko
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*******************************************************************************/
+
 #include "CompilerErrorHandlerRegistrar.h"
 
 uint32_t CompilerErrorHandlerRegistrar::_registeredID = 0;

--- a/src/CompilerErrorHandlerRegistrar.cpp
+++ b/src/CompilerErrorHandlerRegistrar.cpp
@@ -1,0 +1,4 @@
+#include "CompilerErrorHandlerRegistrar.h"
+
+uint32_t CompilerErrorHandlerRegistrar::_registeredID = 0;
+CompilerErrorPrinter* CompilerErrorHandlerRegistrar::_errorPrinter = nullptr;

--- a/src/CompilerErrorHandlerRegistrar.h
+++ b/src/CompilerErrorHandlerRegistrar.h
@@ -1,3 +1,26 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2020 Tomiko
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*******************************************************************************/
+
 #pragma once
 
 #include "CompilerErrorPrinter.h"

--- a/src/CompilerErrorHandlerRegistrar.h
+++ b/src/CompilerErrorHandlerRegistrar.h
@@ -1,51 +1,53 @@
 #pragma once
 
-#include <cstdint>
-
 #include "CompilerErrorPrinter.h"
 
-class CompilerErrorHandlerRegistrar {
+#include <cassert>
+#include <cstdint>
+
+class CompilerErrorHandlerRegistrar
+{
 private:
-    static uint32_t _registeredID;
+  static uint32_t _registeredID;
 
 public:
-    template <typename T>
-    static void RegisterScopedCompilerErrorHandler(T* handler) {
-        switch (T::ID) {
-        case CompilerErrorPrinter::ID:
-            _errorPrinter = handler;
-            _registeredID = T::ID;
-            break;
-        default:
-            break;
-        }
+  template <typename T>
+  static void RegisterScopedCompilerErrorHandler(T* handler)
+  {
+    switch (T::ID) {
+      case CompilerErrorPrinter::ID:
+        _errorPrinter = handler;
+        _registeredID = T::ID;
+        break;
+      default:
+        break;
     }
+  }
 
-    static void RegisterCompilerError(CompilerError&& error) {
-        switch (_registeredID) {
-        case CompilerErrorPrinter::ID:
-            _errorPrinter->printError(error);
-            break;
-        default:
-            break;
-        }
+  static void RegisterCompilerError(CompilerError&& error)
+  {
+    switch (_registeredID) {
+      case CompilerErrorPrinter::ID:
+        assert(_errorPrinter && "Expects _errorPrinter to be present");
+        _errorPrinter->printError(error);
+        break;
+      default:
+        break;
     }
+  }
 
-    static void UnregisterScopedCompilerErrorHandler() {
-        switch (_registeredID) {
-        case CompilerErrorPrinter::ID:
-            _errorPrinter = nullptr;
-            break;
-        default:
-            break;
-        }
-        _registeredID = 0;
+  static void UnregisterScopedCompilerErrorHandler()
+  {
+    switch (_registeredID) {
+      case CompilerErrorPrinter::ID:
+        _errorPrinter = nullptr;
+        break;
+      default:
+        break;
     }
+    _registeredID = 0;
+  }
 
 private:
-   static CompilerErrorPrinter* _errorPrinter; 
+  static CompilerErrorPrinter* _errorPrinter;
 };
-
-uint32_t CompilerErrorHandlerRegistrar::_registeredID = 0;
-CompilerErrorPrinter* CompilerErrorHandlerRegistrar::_errorPrinter = nullptr;
-

--- a/src/CompilerErrorHandlerRegistrar.h
+++ b/src/CompilerErrorHandlerRegistrar.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <cstdint>
+
+#include "CompilerErrorPrinter.h"
+
+class CompilerErrorHandlerRegistrar {
+private:
+    static uint32_t _registeredID;
+
+public:
+    template <typename T>
+    static void RegisterScopedCompilerErrorHandler(T* handler) {
+        switch (T::ID) {
+        case CompilerErrorPrinter::ID:
+            _errorPrinter = handler;
+            _registeredID = T::ID;
+            break;
+        default:
+            break;
+        }
+    }
+
+    static void RegisterCompilerError(CompilerError&& error) {
+        switch (_registeredID) {
+        case CompilerErrorPrinter::ID:
+            _errorPrinter->printError(error);
+            break;
+        default:
+            break;
+        }
+    }
+
+    static void UnregisterScopedCompilerErrorHandler() {
+        switch (_registeredID) {
+        case CompilerErrorPrinter::ID:
+            _errorPrinter = nullptr;
+            break;
+        default:
+            break;
+        }
+        _registeredID = 0;
+    }
+
+private:
+   static CompilerErrorPrinter* _errorPrinter; 
+};
+
+uint32_t CompilerErrorHandlerRegistrar::_registeredID = 0;
+CompilerErrorPrinter* CompilerErrorHandlerRegistrar::_errorPrinter = nullptr;
+

--- a/src/CompilerErrorHandlerRegistrar.h
+++ b/src/CompilerErrorHandlerRegistrar.h
@@ -74,3 +74,17 @@ public:
 private:
   static CompilerErrorPrinter* _errorPrinter;
 };
+
+template <typename T>
+struct ScopedCompilerErrorHandlerRegister
+{
+  explicit ScopedCompilerErrorHandlerRegister(T* handler)
+  {
+    CompilerErrorHandlerRegistrar::RegisterScopedCompilerErrorHandler<T>(
+        handler);
+  }
+  ~ScopedCompilerErrorHandlerRegister()
+  {
+    CompilerErrorHandlerRegistrar::UnregisterScopedCompilerErrorHandler();
+  }
+};

--- a/src/CompilerErrorHandlerRegistrar.h
+++ b/src/CompilerErrorHandlerRegistrar.h
@@ -83,6 +83,7 @@ struct ScopedCompilerErrorHandlerRegister
     CompilerErrorHandlerRegistrar::RegisterScopedCompilerErrorHandler<T>(
         handler);
   }
+
   ~ScopedCompilerErrorHandlerRegister()
   {
     CompilerErrorHandlerRegistrar::UnregisterScopedCompilerErrorHandler();

--- a/src/CompilerErrorPrinter.h
+++ b/src/CompilerErrorPrinter.h
@@ -26,11 +26,13 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "CompilerError.h"
 
 #include <algorithm>
+#include <cstdint>
 #include <iostream>
 #include <string>
 
 struct CompilerErrorPrinter
 {
+    static const uint32_t ID = 1;
   CompilerErrorPrinter(const std::string& inputFilepath, std::ostream& stream)
     : _inputFilepath(inputFilepath)
     , _out(stream)

--- a/src/CompilerErrorPrinter.h
+++ b/src/CompilerErrorPrinter.h
@@ -32,7 +32,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 struct CompilerErrorPrinter
 {
-    static const uint32_t ID = 1;
+  static const uint32_t ID = 1;
   CompilerErrorPrinter(const std::string& inputFilepath, std::ostream& stream)
     : _inputFilepath(inputFilepath)
     , _out(stream)

--- a/src/CompilerErrorPrinter.h
+++ b/src/CompilerErrorPrinter.h
@@ -33,6 +33,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 struct CompilerErrorPrinter
 {
   static const uint32_t ID = 1;
+
   CompilerErrorPrinter(const std::string& inputFilepath, std::ostream& stream)
     : _inputFilepath(inputFilepath)
     , _out(stream)

--- a/src/ProgramDriver.cpp
+++ b/src/ProgramDriver.cpp
@@ -25,6 +25,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "CmdlDriver.h"
 #include "CompilerErrorPrinter.h"
+#include "CompilerErrorHandlerRegistrar.h"
 #include "SemanticAnalyzer.h"
 #include "SynthesisErrorCategory.h"
 #include "Synthesizer.h"
@@ -67,6 +68,9 @@ ProgramDriver::run(int argc, char** argv)
   }
 
   CompilerErrorPrinter errorPrinter(cmdlOpts.inputPath, std::cout);
+
+  CompilerErrorHandlerRegistrar::RegisterScopedCompilerErrorHandler<
+    CompilerErrorPrinter>(&errorPrinter);
 
   // Parsing.
   ParserDriver::Options parserOpts{.traceLexer = cmdlOpts.debugMode,

--- a/src/ProgramDriver.cpp
+++ b/src/ProgramDriver.cpp
@@ -100,7 +100,7 @@ ProgramDriver::run(int argc, char** argv)
   Synthesizer::Options synthesisOpts{.useException = false,
                                      .outputPath = cmdlOpts.outputPath};
   Synthesizer synthesizer(synthesisOpts);
-  res = synthesizer.run(module, &errorPrinter);
+  res = synthesizer.run(module);
   if (!res) {
     if (!cmdlOpts.silent) {
       fprintf(stderr, "Error: Failed to synthesize output to: %s\n",

--- a/src/ProgramDriver.cpp
+++ b/src/ProgramDriver.cpp
@@ -24,8 +24,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "ProgramDriver.h"
 
 #include "CmdlDriver.h"
-#include "CompilerErrorPrinter.h"
 #include "CompilerErrorHandlerRegistrar.h"
+#include "CompilerErrorPrinter.h"
 #include "SemanticAnalyzer.h"
 #include "SynthesisErrorCategory.h"
 #include "Synthesizer.h"
@@ -70,7 +70,7 @@ ProgramDriver::run(int argc, char** argv)
   CompilerErrorPrinter errorPrinter(cmdlOpts.inputPath, std::cout);
 
   CompilerErrorHandlerRegistrar::RegisterScopedCompilerErrorHandler<
-    CompilerErrorPrinter>(&errorPrinter);
+      CompilerErrorPrinter>(&errorPrinter);
 
   // Parsing.
   ParserDriver::Options parserOpts{.traceLexer = cmdlOpts.debugMode,
@@ -78,7 +78,6 @@ ProgramDriver::run(int argc, char** argv)
                                    .suppressErrorMessages = false};
 
   ParserDriver parser(parserOpts);
-  parser.setCompilerErrorPrinter(&errorPrinter);
   res = parser.parseFromFile(cmdlOpts.inputPath);
   if (res != 0) {
     return EXIT_FAILURE;

--- a/src/ProgramDriver.cpp
+++ b/src/ProgramDriver.cpp
@@ -91,9 +91,6 @@ ProgramDriver::run(int argc, char** argv)
       .warningsAsErrors = cmdlOpts.warningsAsErrors,
       .verbose = cmdlOpts.debugMode};
   SemanticAnalyzer semaAnalyzer(semaOpts);
-  if (!cmdlOpts.silent) {
-    semaAnalyzer.setCompilerErrorPrinter(&errorPrinter);
-  }
   res = semaAnalyzer.run(module);
   if (!res) {
     return EXIT_FAILURE;

--- a/src/ProgramDriver.cpp
+++ b/src/ProgramDriver.cpp
@@ -69,8 +69,8 @@ ProgramDriver::run(int argc, char** argv)
 
   CompilerErrorPrinter errorPrinter(cmdlOpts.inputPath, std::cout);
 
-  CompilerErrorHandlerRegistrar::RegisterScopedCompilerErrorHandler<
-      CompilerErrorPrinter>(&errorPrinter);
+  ScopedCompilerErrorHandlerRegister<CompilerErrorPrinter>
+      scopedCompilerErrorHandlerRegister(&errorPrinter);
 
   // Parsing.
   ParserDriver::Options parserOpts{.traceLexer = cmdlOpts.debugMode,

--- a/src/SemanticAnalyzer.cpp
+++ b/src/SemanticAnalyzer.cpp
@@ -82,7 +82,6 @@ struct InferenceDefnContext
 SemanticAnalyzer::SemanticAnalyzer()
   : ASTVisitor()
   , _opts()
-  , _errorPrinter(nullptr)
 {
 }
 
@@ -91,7 +90,6 @@ SemanticAnalyzer::SemanticAnalyzer()
 SemanticAnalyzer::SemanticAnalyzer(const Options& opts)
   : ASTVisitor()
   , _opts(opts)
-  , _errorPrinter(nullptr)
 {
 }
 
@@ -101,14 +99,6 @@ const SemanticAnalyzer::Options&
 SemanticAnalyzer::options() const
 {
   return _opts;
-}
-
-// -----------------------------------------------------------------------------
-
-void
-SemanticAnalyzer::setCompilerErrorPrinter(CompilerErrorPrinter* errorPrinter)
-{
-  _errorPrinter = errorPrinter;
 }
 
 // -----------------------------------------------------------------------------

--- a/src/SemanticAnalyzer.h
+++ b/src/SemanticAnalyzer.h
@@ -26,7 +26,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "ASTUtils.h"
 #include "ASTVisitor.h"
 #include "CompilerError.h"
-#include "CompilerErrorPrinter.h"
+#include "CompilerErrorHandlerRegistrar.h"
 #include "SemanticAnalysisErrorCategory.h"
 
 #include <cstdio>
@@ -83,12 +83,9 @@ private:
     } else {
       char buffer[MAX_MSG_LEN] = {0};
       snprintf(buffer, sizeof(buffer), msg, args...);
-      if (_errorPrinter) {
-        _errorPrinter->printError(
-            SemanticAnalysisErrorCategory::
-                CreateCompilerErrorWithTypeAndMessage(
-                    CompilerError::Type::Warning, code, buffer));
-      }
+      CompilerErrorHandlerRegistrar::RegisterCompilerError(
+          SemanticAnalysisErrorCategory::CreateCompilerErrorWithTypeAndMessage(
+              CompilerError::Type::Warning, code, buffer));
     }
   }
 
@@ -97,13 +94,10 @@ private:
   {
     char buffer[MAX_MSG_LEN] = {0};
     snprintf(buffer, sizeof(buffer), msg, args...);
-    if (_errorPrinter) {
-      _errorPrinter->printError(
-          SemanticAnalysisErrorCategory::CreateCompilerErrorWithTypeAndMessage(
-              CompilerError::Type::Error, code, buffer));
-    }
+    CompilerErrorHandlerRegistrar::RegisterCompilerError(
+        SemanticAnalysisErrorCategory::CreateCompilerErrorWithTypeAndMessage(
+            CompilerError::Type::Error, code, buffer));
   }
 
   Options _opts;
-  CompilerErrorPrinter* _errorPrinter;
 };

--- a/src/Synthesizer.h
+++ b/src/Synthesizer.h
@@ -27,8 +27,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include <string>
 
-struct CompilerErrorPrinter;
-
 class Synthesizer
 {
 public:
@@ -42,7 +40,7 @@ public:
 
   explicit Synthesizer(const Options&);
 
-  bool run(const ASTModule&, CompilerErrorPrinter* = nullptr) const;
+  bool run(const ASTModule&) const;
 
 private:
   Options _opts;

--- a/src/parser/ParserDriver.cpp
+++ b/src/parser/ParserDriver.cpp
@@ -22,6 +22,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
 #include "ParserDriver.h"
 
+#include "../CompilerErrorHandlerRegistrar.h"
 #include "ParserErrorCategory.h"
 #include "ParserErrorCodes.h"
 #include "lex.yy.hh"
@@ -40,7 +41,6 @@ ParserDriver::ParserDriver()
                                 .suppressErrorMessages = false})
   , _inputFile()
   , _module()
-  , _errorPrinter(nullptr)
 {
 }
 
@@ -50,7 +50,6 @@ ParserDriver::ParserDriver(Options opts)
   : _opts(opts)
   , _inputFile()
   , _module()
-  , _errorPrinter(nullptr)
 {
 }
 
@@ -188,24 +187,12 @@ ParserDriver::setModule(ASTModule&& module)
 // -----------------------------------------------------------------------------
 
 void
-ParserDriver::setCompilerErrorPrinter(CompilerErrorPrinter* errorPrinter)
-{
-  _errorPrinter = errorPrinter;
-}
-
-// -----------------------------------------------------------------------------
-
-void
 ParserDriver::handleErrorWithMessageAndCode(const char* msg,
                                             CompilerError::Code code)
 {
-  if (_errorPrinter) {
-    _errorPrinter->printError(
-        ParserErrorCategory::CreateCompilerErrorWithTypeAndMessage(
-            CompilerError::Type::Error, code, msg));
-  } else {
-    fprintf(stderr, "%s\n", msg);
-  }
+  CompilerErrorHandlerRegistrar::RegisterCompilerError(
+      ParserErrorCategory::CreateCompilerErrorWithTypeAndMessage(
+          CompilerError::Type::Error, code, msg));
 }
 
 // -----------------------------------------------------------------------------

--- a/src/parser/ParserDriver.h
+++ b/src/parser/ParserDriver.h
@@ -23,7 +23,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #pragma once
 
-#include "../CompilerErrorPrinter.h"
+#include "../CompilerError.h"
 #include "ast.h"
 #include "location.hh"
 #include "parser.tab.hh"
@@ -100,8 +100,6 @@ public:
   void error(const yy::location& l, const std::string& m);
   void error(const std::string& m);
 
-  void setCompilerErrorPrinter(CompilerErrorPrinter*);
-
 private:
   void handleErrorWithMessageAndCode(const char*, CompilerError::Code);
 
@@ -109,5 +107,4 @@ private:
   Options _opts;
   std::string _inputFile;
   ASTModule _module;
-  CompilerErrorPrinter* _errorPrinter;
 };


### PR DESCRIPTION
This patch is the continuation of the work done in #61 to consolidate the handling of compiler errors and warnings mechanism.

Specifically, this patch attempts to completely decouple the error handling mechanism from core compiler components by introducing a global `CompilerErrorHandlerRegistrar` component for registering both error handler and errors.