### PR TITLE
Refactor compiler errors and warnings handling - Part 3

### DIFF
--- a/src/CompilerErrorHandlerRegistrar.cpp
+++ b/src/CompilerErrorHandlerRegistrar.cpp
@@ -25,8 +25,48 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 // -----------------------------------------------------------------------------
 
-uint32_t CompilerErrorHandlerRegistrar::_registeredID = 0;
+CompilerErrorHandler CompilerErrorHandlerRegistrar::_registeredHandler =
+    nullptr;
 
-CompilerErrorPrinter* CompilerErrorHandlerRegistrar::_errorPrinter = nullptr;
+// -----------------------------------------------------------------------------
+
+void
+CompilerErrorHandlerRegistrar::RegisterScopedCompilerErrorHandler(
+    CompilerErrorHandler handler)
+{
+  _registeredHandler = handler;
+}
+
+// -----------------------------------------------------------------------------
+
+void
+CompilerErrorHandlerRegistrar::RegisterCompilerError(CompilerError&& error)
+{
+  if (_registeredHandler)
+    _registeredHandler(error);
+}
+
+// -----------------------------------------------------------------------------
+
+void
+CompilerErrorHandlerRegistrar::UnregisterScopedCompilerErrorHandler()
+{
+  _registeredHandler = nullptr;
+}
+
+// -----------------------------------------------------------------------------
+
+ScopedCompilerErrorHandlerRegister::ScopedCompilerErrorHandlerRegister(
+    CompilerErrorHandler handler)
+{
+  CompilerErrorHandlerRegistrar::RegisterScopedCompilerErrorHandler(handler);
+}
+
+// -----------------------------------------------------------------------------
+
+ScopedCompilerErrorHandlerRegister::~ScopedCompilerErrorHandlerRegister()
+{
+  CompilerErrorHandlerRegistrar::UnregisterScopedCompilerErrorHandler();
+}
 
 // -----------------------------------------------------------------------------

--- a/src/CompilerErrorHandlerRegistrar.h
+++ b/src/CompilerErrorHandlerRegistrar.h
@@ -23,69 +23,28 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #pragma once
 
-#include "CompilerErrorPrinter.h"
+#include "CompilerError.h"
 
-#include <cassert>
-#include <cstdint>
+#include <functional>
+
+typedef std::function<void(CompilerError)> CompilerErrorHandler;
 
 class CompilerErrorHandlerRegistrar
 {
-private:
-  static uint32_t _registeredID;
-
 public:
-  template <typename T>
-  static void RegisterScopedCompilerErrorHandler(T* handler)
-  {
-    switch (T::ID) {
-      case CompilerErrorPrinter::ID:
-        _errorPrinter = handler;
-        _registeredID = T::ID;
-        break;
-      default:
-        break;
-    }
-  }
+  static void RegisterScopedCompilerErrorHandler(CompilerErrorHandler);
 
-  static void RegisterCompilerError(CompilerError&& error)
-  {
-    switch (_registeredID) {
-      case CompilerErrorPrinter::ID:
-        assert(_errorPrinter && "Expects _errorPrinter to be present");
-        _errorPrinter->printError(error);
-        break;
-      default:
-        break;
-    }
-  }
+  static void RegisterCompilerError(CompilerError&&);
 
-  static void UnregisterScopedCompilerErrorHandler()
-  {
-    switch (_registeredID) {
-      case CompilerErrorPrinter::ID:
-        _errorPrinter = nullptr;
-        break;
-      default:
-        break;
-    }
-    _registeredID = 0;
-  }
+  static void UnregisterScopedCompilerErrorHandler();
 
 private:
-  static CompilerErrorPrinter* _errorPrinter;
+  static CompilerErrorHandler _registeredHandler;
 };
 
-template <typename T>
 struct ScopedCompilerErrorHandlerRegister
 {
-  explicit ScopedCompilerErrorHandlerRegister(T* handler)
-  {
-    CompilerErrorHandlerRegistrar::RegisterScopedCompilerErrorHandler<T>(
-        handler);
-  }
+  explicit ScopedCompilerErrorHandlerRegister(CompilerErrorHandler);
 
-  ~ScopedCompilerErrorHandlerRegister()
-  {
-    CompilerErrorHandlerRegistrar::UnregisterScopedCompilerErrorHandler();
-  }
+  ~ScopedCompilerErrorHandlerRegister();
 };

--- a/src/ProgramDriver.cpp
+++ b/src/ProgramDriver.cpp
@@ -69,8 +69,12 @@ ProgramDriver::run(int argc, char** argv)
 
   CompilerErrorPrinter errorPrinter(cmdlOpts.inputPath, std::cout);
 
-  ScopedCompilerErrorHandlerRegister<CompilerErrorPrinter>
-      scopedCompilerErrorHandlerRegister(&errorPrinter);
+  auto errorHandlerHook = [&](CompilerError error) -> void {
+    errorPrinter.printError(error);
+  };
+
+  ScopedCompilerErrorHandlerRegister scopedCompilerErrorHandlerRegister(
+      errorHandlerHook);
 
   // Parsing.
   ParserDriver::Options parserOpts{.traceLexer = cmdlOpts.debugMode,

--- a/src/SemanticAnalyzer.h
+++ b/src/SemanticAnalyzer.h
@@ -54,8 +54,6 @@ public:
 
   const Options& options() const;
 
-  void setCompilerErrorPrinter(CompilerErrorPrinter*);
-
 private:
   bool previsit(const ASTModule&) override;
   bool previsit(const ASTInferenceGroup&) override;


### PR DESCRIPTION
This patch is the continuation of the work done in #65 to consolidate and refine the handling of compiler errors and warnings mechanism.

Specifically, this patch builds on top of the work done in #65 and refines the compiler error handler registration mechanism to be a simpler API.