### PR TITLE
[CI] Enable macOS builds on GitHub Action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        platform: [ubuntu-latest]
+        platform: [ubuntu-latest, macos-10.15]
 
     runs-on: ${{ matrix.platform }}
 


### PR DESCRIPTION
Add 'macos-10.15' to platform matrix.

Successful build:
https://github.com/tetrachrome/Snowlake/pull/69/checks?check_run_id=1072971798